### PR TITLE
Fixed size of GamePanel

### DIFF
--- a/src/com/palmstudios/Escape.java
+++ b/src/com/palmstudios/Escape.java
@@ -33,9 +33,9 @@ public class Escape {
 		hwnd.setSize(GamePanel.WIDTH, GamePanel.HEIGHT);
 		hwnd.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		hwnd.add(gpan);
-		hwnd.setPreferredSize(new Dimension(GamePanel.WIDTH * GamePanel.SCALE, GamePanel.HEIGHT * GamePanel.SCALE));
 		hwnd.setResizable(false);
 		hwnd.setVisible(true);
 		hwnd.pack();
+		hwnd.setPreferredSize(new Dimension(GamePanel.WIDTH * GamePanel.SCALE, GamePanel.HEIGHT * GamePanel.SCALE));
 	}
 }


### PR DESCRIPTION
Fixed the sizing of GamePanel in Escape.java. The GamePanel itself is
now 640x480 instead of just the frame being that size.